### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Continuous Integration Checks
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Jer-Pha/kfai-pipeline/security/code-scanning/1](https://github.com/Jer-Pha/kfai-pipeline/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and run tests/linters, it only requires read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
